### PR TITLE
Add food-themed hero illustrations and fix empty logo

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -298,15 +298,15 @@ ul, ol {
 }
 
 .nav-logo-img {
-	height: 40px;
-	width: auto;
-	filter: brightness(0) invert(1);
-	transition: filter var(--transition);
+	height: 36px;
+	width: 36px;
+	color: #fff;
+	transition: color var(--transition);
 }
 
 .site-nav.scrolled .nav-logo-img,
 .site-nav--solid .nav-logo-img {
-	filter: none;
+	color: var(--color-primary);
 }
 
 .nav-logo-text {
@@ -418,8 +418,87 @@ ul, ol {
 	pointer-events: none;
 }
 
+/* Hero botanical food illustrations */
+.hero-botanicals {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	pointer-events: none;
+	overflow: hidden;
+}
+
+.botanical {
+	position: absolute;
+	color: rgba(255, 255, 255, 0.07);
+}
+
+.botanical-1 {
+	width: 180px;
+	top: 5%;
+	left: -20px;
+	transform: rotate(-15deg);
+	animation: floatSlow 20s ease-in-out infinite;
+}
+
+.botanical-2 {
+	width: 100px;
+	top: 12%;
+	right: 8%;
+	transform: rotate(10deg);
+	color: rgba(201, 169, 110, 0.1);
+	animation: floatSlow 25s ease-in-out infinite reverse;
+}
+
+.botanical-3 {
+	width: 120px;
+	bottom: 15%;
+	right: 5%;
+	transform: rotate(15deg);
+	animation: floatSlow 22s ease-in-out infinite;
+}
+
+.botanical-4 {
+	width: 80px;
+	bottom: 20%;
+	left: 8%;
+	transform: rotate(-10deg);
+	color: rgba(201, 169, 110, 0.08);
+	animation: floatSlow 18s ease-in-out infinite reverse;
+}
+
+.botanical-5 {
+	width: 130px;
+	top: 35%;
+	right: -15px;
+	transform: rotate(5deg);
+	animation: floatSlow 24s ease-in-out infinite;
+}
+
+.botanical-6 {
+	width: 90px;
+	top: 40%;
+	left: 5%;
+	transform: rotate(-20deg);
+	animation: floatSlow 21s ease-in-out infinite reverse;
+}
+
+@keyframes floatSlow {
+	0%, 100% { transform: translateY(0) rotate(var(--r, 0deg)); }
+	50% { transform: translateY(-15px) rotate(var(--r, 0deg)); }
+}
+
+.botanical-1 { --r: -15deg; }
+.botanical-2 { --r: 10deg; }
+.botanical-3 { --r: 15deg; }
+.botanical-4 { --r: -10deg; }
+.botanical-5 { --r: 5deg; }
+.botanical-6 { --r: -20deg; }
+
 .hero-content {
 	position: relative;
+	z-index: 2;
 	text-align: center;
 	padding: var(--space-lg);
 	max-width: 750px;
@@ -1089,10 +1168,9 @@ ul, ol {
 
 .footer-logo {
 	height: 40px;
-	width: auto;
+	width: 40px;
 	margin: 0 auto var(--space-sm);
-	filter: brightness(0) invert(1);
-	opacity: 0.7;
+	color: rgba(255, 255, 255, 0.6);
 }
 
 .footer-tagline {
@@ -1417,6 +1495,10 @@ ul, ol {
 		font-size: 1rem;
 	}
 
+	.hero-botanicals {
+		opacity: 0.5;
+	}
+
 	.section-title {
 		font-size: 2rem;
 	}
@@ -1472,6 +1554,10 @@ ul, ol {
 
 	.hero {
 		min-height: 90vh;
+	}
+
+	.hero-botanicals {
+		display: none;
 	}
 
 	.hero-title {

--- a/images/logo-leaf.svg
+++ b/images/logo-leaf.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
+  <!-- Elegant leaf logo for Diet & Obesity Clinic -->
+  <path d="M24 4C24 4 8 14 8 28c0 8 7.2 16 16 16s16-8 16-16C40 14 24 4 24 4z" fill="currentColor" opacity="0.9"/>
+  <path d="M24 12v28" stroke="white" stroke-width="1.5" stroke-linecap="round" opacity="0.6"/>
+  <path d="M24 18c-4 2-7 5.5-8 10" stroke="white" stroke-width="1.2" stroke-linecap="round" fill="none" opacity="0.5"/>
+  <path d="M24 22c4 2.5 6.5 5.5 7 9" stroke="white" stroke-width="1.2" stroke-linecap="round" fill="none" opacity="0.5"/>
+  <path d="M24 28c-3 1.5-5 3.5-5.5 6" stroke="white" stroke-width="1" stroke-linecap="round" fill="none" opacity="0.4"/>
+  <path d="M24 30c2.5 1.5 4 3 4.5 5" stroke="white" stroke-width="1" stroke-linecap="round" fill="none" opacity="0.4"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
 	<nav class="site-nav" id="nav">
 		<div class="nav-inner">
 			<a href="#" class="nav-logo">
-				<img src="images/nutritionist.svg" alt="Logo" class="nav-logo-img" />
+				<img src="images/logo-leaf.svg" alt="Logo" class="nav-logo-img" />
 				<span class="nav-logo-text">Dr. Usha Harish</span>
 			</a>
 			<button class="nav-toggle" id="navToggle" aria-label="Toggle navigation">
@@ -40,6 +40,57 @@
 	<!-- Hero Section -->
 	<header class="hero" id="hero">
 		<div class="hero-overlay"></div>
+		<!-- Botanical food illustrations -->
+		<div class="hero-botanicals" aria-hidden="true">
+			<svg class="botanical botanical-1" viewBox="0 0 200 300" fill="none" xmlns="http://www.w3.org/2000/svg">
+				<!-- Leafy branch -->
+				<path d="M100 280 C100 280 100 20 100 20" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+				<ellipse cx="70" cy="60" rx="35" ry="20" transform="rotate(-30 70 60)" stroke="currentColor" stroke-width="1" fill="none"/>
+				<ellipse cx="130" cy="90" rx="35" ry="20" transform="rotate(30 130 90)" stroke="currentColor" stroke-width="1" fill="none"/>
+				<ellipse cx="65" cy="130" rx="30" ry="18" transform="rotate(-25 65 130)" stroke="currentColor" stroke-width="1" fill="none"/>
+				<ellipse cx="135" cy="160" rx="30" ry="18" transform="rotate(25 135 160)" stroke="currentColor" stroke-width="1" fill="none"/>
+				<ellipse cx="72" cy="200" rx="25" ry="15" transform="rotate(-20 72 200)" stroke="currentColor" stroke-width="1" fill="none"/>
+				<ellipse cx="128" cy="230" rx="25" ry="15" transform="rotate(20 128 230)" stroke="currentColor" stroke-width="1" fill="none"/>
+			</svg>
+			<svg class="botanical botanical-2" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+				<!-- Apple / fruit -->
+				<path d="M60 25 C60 25 55 10 48 10 C40 10 38 20 42 25" stroke="currentColor" stroke-width="1" fill="none"/>
+				<path d="M60 25 C35 25 15 50 20 75 C25 100 45 110 60 110 C75 110 95 100 100 75 C105 50 85 25 60 25Z" stroke="currentColor" stroke-width="1.2" fill="none"/>
+				<path d="M60 25 C60 30 58 45 55 55" stroke="currentColor" stroke-width="0.8" fill="none" stroke-linecap="round"/>
+			</svg>
+			<svg class="botanical botanical-3" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+				<!-- Citrus slice -->
+				<circle cx="80" cy="80" r="55" stroke="currentColor" stroke-width="1.2"/>
+				<circle cx="80" cy="80" r="45" stroke="currentColor" stroke-width="0.8"/>
+				<line x1="80" y1="35" x2="80" y2="125" stroke="currentColor" stroke-width="0.6"/>
+				<line x1="35" y1="80" x2="125" y2="80" stroke="currentColor" stroke-width="0.6"/>
+				<line x1="48" y1="48" x2="112" y2="112" stroke="currentColor" stroke-width="0.6"/>
+				<line x1="112" y1="48" x2="48" y2="112" stroke="currentColor" stroke-width="0.6"/>
+			</svg>
+			<svg class="botanical botanical-4" viewBox="0 0 100 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+				<!-- Carrot -->
+				<path d="M50 15 C35 15 30 30 35 35 L50 170 L65 35 C70 30 65 15 50 15Z" stroke="currentColor" stroke-width="1" fill="none"/>
+				<path d="M42 10 C42 10 48 18 50 15 C52 18 58 10 58 10" stroke="currentColor" stroke-width="0.8" fill="none"/>
+				<path d="M38 55 L62 55" stroke="currentColor" stroke-width="0.5" stroke-linecap="round"/>
+				<path d="M40 80 L60 80" stroke="currentColor" stroke-width="0.5" stroke-linecap="round"/>
+				<path d="M43 105 L57 105" stroke="currentColor" stroke-width="0.5" stroke-linecap="round"/>
+				<path d="M45 130 L55 130" stroke="currentColor" stroke-width="0.5" stroke-linecap="round"/>
+			</svg>
+			<svg class="botanical botanical-5" viewBox="0 0 140 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+				<!-- Herb sprig -->
+				<path d="M70 190 C70 190 70 10 70 10" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>
+				<path d="M70 40 C50 30 30 35 30 50 C30 65 50 60 70 55" stroke="currentColor" stroke-width="0.8" fill="none"/>
+				<path d="M70 70 C90 60 110 65 110 80 C110 95 90 90 70 85" stroke="currentColor" stroke-width="0.8" fill="none"/>
+				<path d="M70 100 C50 90 35 95 35 110 C35 125 50 118 70 113" stroke="currentColor" stroke-width="0.8" fill="none"/>
+				<path d="M70 130 C90 120 105 125 105 138 C105 150 90 145 70 140" stroke="currentColor" stroke-width="0.8" fill="none"/>
+				<path d="M70 155 C55 148 42 152 42 162 C42 172 55 168 70 164" stroke="currentColor" stroke-width="0.8" fill="none"/>
+			</svg>
+			<svg class="botanical botanical-6" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+				<!-- Avocado -->
+				<path d="M50 10 C25 10 8 35 8 55 C8 80 25 90 50 90 C75 90 92 80 92 55 C92 35 75 10 50 10Z" stroke="currentColor" stroke-width="1" fill="none"/>
+				<ellipse cx="50" cy="60" rx="18" ry="20" stroke="currentColor" stroke-width="0.8" fill="none"/>
+			</svg>
+		</div>
 		<div class="hero-content">
 			<p class="hero-label">Clinical Nutritionist &amp; Obesity Specialist</p>
 			<h1 class="hero-title">Diet &amp; Obesity Clinic</h1>
@@ -433,7 +484,7 @@
 		<div class="container">
 			<div class="footer-inner">
 				<div class="footer-brand">
-					<img src="images/nutritionist.svg" alt="Logo" class="footer-logo" />
+					<img src="images/logo-leaf.svg" alt="Logo" class="footer-logo" />
 					<p class="footer-tagline">Diet &amp; Obesity Clinic</p>
 					<p class="footer-tagline-sub">Get Healthy by Eating Right</p>
 				</div>

--- a/testimonials.html
+++ b/testimonials.html
@@ -18,7 +18,7 @@
 	<nav class="site-nav site-nav--solid" id="nav">
 		<div class="nav-inner">
 			<a href="index.html" class="nav-logo">
-				<img src="images/nutritionist.svg" alt="Logo" class="nav-logo-img" />
+				<img src="images/logo-leaf.svg" alt="Logo" class="nav-logo-img" />
 				<span class="nav-logo-text">Dr. Usha Harish</span>
 			</a>
 			<button class="nav-toggle" id="navToggle" aria-label="Toggle navigation">
@@ -224,7 +224,7 @@
 		<div class="container">
 			<div class="footer-inner">
 				<div class="footer-brand">
-					<img src="images/nutritionist.svg" alt="Logo" class="footer-logo" />
+					<img src="images/logo-leaf.svg" alt="Logo" class="footer-logo" />
 					<p class="footer-tagline">Diet &amp; Obesity Clinic</p>
 					<p class="footer-tagline-sub">Get Healthy by Eating Right</p>
 				</div>


### PR DESCRIPTION
- Create new logo-leaf.svg: clean single-color leaf icon that renders properly with CSS color inheritance (replaces broken nutritionist.svg which turned into a blank white blob with the brightness filter)
- Add 6 botanical SVG illustrations to hero background: leafy branch, apple, citrus slice, carrot, herb sprig, and avocado rendered as elegant line art with subtle opacity and gentle floating animation
- Logo uses currentColor so it appears white on dark nav/footer and switches to primary green when nav becomes solid on scroll
- Botanicals hidden on mobile portrait for clean small-screen experience
