### PR TITLE
Fix carousel mobile responsiveness and double-slide bug

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -750,8 +750,9 @@ ul, ol {
 }
 
 .carousel-slide {
-	min-width: 100%;
-	flex-shrink: 0;
+	flex: 0 0 100%;
+	width: 100%;
+	max-width: 100%;
 }
 
 .carousel-slide img {
@@ -759,7 +760,7 @@ ul, ol {
 	height: auto;
 	display: block;
 	object-fit: contain;
-	max-height: 600px;
+	max-height: 70vh;
 	background: #f9f9f9;
 }
 
@@ -878,7 +879,6 @@ ul, ol {
 .testimonials-carousel {
 	position: relative;
 	overflow: hidden;
-	padding: 0 var(--space-xl);
 }
 
 .testimonials-track {
@@ -887,8 +887,9 @@ ul, ol {
 }
 
 .testimonial-card {
-	min-width: 100%;
-	flex-shrink: 0;
+	flex: 0 0 100%;
+	width: 100%;
+	max-width: 100%;
 	padding: 0 var(--space-sm);
 }
 
@@ -1515,8 +1516,9 @@ ul, ol {
 		min-width: 120px;
 	}
 
-	.testimonials-carousel {
-		padding: 0 var(--space-lg);
+	.testimonials-carousel .carousel-btn {
+		width: 40px;
+		height: 40px;
 	}
 
 	.testimonial-full-card {
@@ -1610,8 +1612,10 @@ ul, ol {
 		right: 8px;
 	}
 
-	.testimonials-carousel {
-		padding: 0 var(--space-sm);
+	.testimonials-carousel .carousel-btn {
+		width: 32px;
+		height: 32px;
+		font-size: 0.75rem;
 	}
 
 	.testimonial-text {


### PR DESCRIPTION
Root cause: translateX percentage is relative to the track's own width (numSlides * containerWidth), not one slide width. On mobile this caused slides to jump by multiple positions per arrow tap.

Fixes:
- Switch carousel from percentage-based to pixel-based translateX, calculated from container.offsetWidth per slide
- Add resize/orientation-change handler that recalculates position instantly (with transition disabled) so carousel stays aligned
- Improve touch handling: track both X and Y movement, only trigger slide change when horizontal swipe exceeds vertical (prevents hijacking page scroll on mobile)
- Use flex: 0 0 100% on slides for reliable cross-browser sizing
- Cap carousel images at 70vh instead of fixed 600px for mobile
- Remove padding from testimonials-carousel that was offsetting the track from its container and breaking pixel calculations

https://claude.ai/code/session_01Dj7GokibFxrHV9gSRUGeQc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved touch and swipe detection for mobile carousel navigation.
  * Enhanced carousel responsiveness on window resize.

* **Bug Fixes**
  * Optimized carousel slide and navigation button sizing across all device breakpoints.
  * Refined slide image scaling for better visual fluidity on different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->